### PR TITLE
Feat layout

### DIFF
--- a/docs/components/alita-layout.md
+++ b/docs/components/alita-layout.md
@@ -225,6 +225,8 @@ const tabBar: TarBarProp
 | badge            | string   | 否   | badge                                                  |
 | onPress          | function | 否   | 点击事件                                               |
 | title            | string   | 否   | 定义页面标题                                           |
+| remove           | boolean  | 否   | 是否删除当前的 tabItem                                 |
+| replace          | string   | 否   | 需要替换的 tabItem 路由                                |
 
 > 关于页面标题，声明权重如下：
 > titleList > list.title > list.text > documentTitle > ''

--- a/docs/components/alita-layout.md
+++ b/docs/components/alita-layout.md
@@ -29,25 +29,17 @@ render(<BasicLayout />, document.getElementById('root'));
 ## Demo
 
 ```ts
-import {
-  NavBarProps,
-  TitleListItem,
-  NavBarListItem,
-  TabBarProps,
-  TabBarListItem,
-  history,
-} from 'alita';
 
 const titleList: TitleListItem[] = [
   {
-    pagePath: '/aa',
-    title: 'a页面',
+    pagePath: '/',
+    title: '首页',
   },
 ];
 
 const navList: NavBarListItem[] = [
   {
-    pagePath: '/aa',
+    pagePath: '/',
     navBar: {},
   },
 ];
@@ -64,22 +56,19 @@ const navBar: NavBarProps = {
 
 const tabList: TabBarListItem[] = [
   {
-    pagePath: '/aa',
-    text: 'aa',
+    pagePath: '/',
+    text: '首页',
     iconPath: img,
     selectedIconPath: img,
-    title: 'aa',
+    title: '首页',
     iconSize: '',
     badge: '',
   },
   {
-    pagePath: '/bb',
-    text: 'bb',
-    iconPath: img,
-    selectedIconPath: img,
-    title: 'bb',
-    iconSize: '',
-    badge: '',
+    pagePath: '/list',
+    text: 'list',
+    title: 'list',
+    ...
   },
 ];
 
@@ -117,19 +106,19 @@ const Page = () => {
 
     setTabBarList([
       {
-        pagePath: '/bb',
+        pagePath: '/list',
         remove: true, // 删除操作
       },
       {
-        pagePath: '/ee',
-        text: 'ee',
+        pagePath: '/home',
+        text: 'home',
         iconPath: img,
         selectedIconPath: img,
-        title: 'ee',
+        title: 'home',
       },
       {
-        pagePath: '/aa',
-        replace: '/dd', // 替换操作
+        pagePath: '/', // 原路由
+        replace: '/index', // 替换操作
         text: 'dd',
         iconPath: img,
         selectedIconPath: img,

--- a/docs/components/alita-layout.md
+++ b/docs/components/alita-layout.md
@@ -141,7 +141,7 @@ const Page = () => {
 };
 ```
 
-### setTabBarList 使用介绍
+### setTabBarList 使用介绍(仅支持 `v2.8.25+` 的 alita 版本)
 
 这里可以传递数组进行多个 `tabItem` 的配置，也可以传递单个 `tabItem` 对象进行配置。
 

--- a/docs/components/alita-layout.md
+++ b/docs/components/alita-layout.md
@@ -26,6 +26,133 @@ import BasicLayout from '@alitajs/alita-layout';
 render(<BasicLayout />, document.getElementById('root'));
 ```
 
+## Demo
+
+```ts
+import {
+  NavBarProps,
+  TitleListItem,
+  NavBarListItem,
+  TabBarProps,
+  TabBarListItem,
+  history,
+} from 'alita';
+
+const titleList: TitleListItem[] = [
+  {
+    pagePath: '/aa',
+    title: 'a页面',
+  },
+];
+
+const navList: NavBarListItem[] = [
+  {
+    pagePath: '/aa',
+    navBar: {},
+  },
+];
+
+const navBar: NavBarProps = {
+  mode: 'light',
+  navList,
+  fixed: true,
+  hideNavBar: false,
+  onLeftClick: () => {
+    history.goBack();
+  },
+};
+
+const tabList: TabBarListItem[] = [
+  {
+    pagePath: '/aa',
+    text: 'aa',
+    iconPath: img,
+    selectedIconPath: img,
+    title: 'aa',
+    iconSize: '',
+    badge: '',
+  },
+  {
+    pagePath: '/bb',
+    text: 'bb',
+    iconPath: img,
+    selectedIconPath: img,
+    title: 'bb',
+    iconSize: '',
+    badge: '',
+  },
+];
+
+const tabBar: TabBarProps = {
+  color: '#696D6C',
+  selectedColor: '#3562AD',
+  borderStyle: 'white',
+  position: 'bottom',
+  list: tabList,
+};
+
+export const mobileLayout = {
+  documentTitle: '默认标题',
+  navBar,
+  tabBar,
+  titleList,
+};
+```
+
+## 动态配置 navBar、tabBar
+
+```js
+import React, { useEffect } from 'react';
+import { setPageNavBar, setTabBarList } from 'alita';
+
+const Page = () => {
+  useEffect(() => {
+    setPageNavBar({
+      pagePath: '/',
+      navBar: {
+        pageTitle: '自定义标题',
+        // 剩余参数请参考 API NavBarProps
+      },
+    });
+
+    setTabBarList([
+      {
+        pagePath: '/bb',
+        remove: true, // 删除操作
+      },
+      {
+        pagePath: '/ee',
+        text: 'ee',
+        iconPath: img,
+        selectedIconPath: img,
+        title: 'ee',
+      },
+      {
+        pagePath: '/aa',
+        replace: '/dd', // 替换操作
+        text: 'dd',
+        iconPath: img,
+        selectedIconPath: img,
+        title: 'dd',
+      },
+    ]);
+  }, []);
+  return <></>;
+};
+```
+
+### setTabBarList 使用介绍
+
+这里可以传递数组进行多个 `tabItem` 的配置，也可以传递单个 `tabItem` 对象进行配置。
+
+**当对象里存在 `remove` 则代表删除该项 `tabItem`。**
+
+**当对象里存在 `replace` 则代表替换该项 `tabItem`。**
+
+当对象里的 `pagePath` 不存在初始的 `tabList` 时，则会新增该项 `tabItem`。
+
+当对象里的 `pagePath` 存在初始的 `tabList` 时，则会修改该项 `tabItem`。
+
 ## API
 
 ### 所有参数说明


### PR DESCRIPTION
setTabBarList 使用介绍(仅支持 v2.8.25+ 的 alita 版本)
这里可以传递数组进行多个 tabItem 的配置，也可以传递单个 tabItem 对象进行配置。

当对象里存在 remove 则代表删除该项 tabItem。

当对象里存在 replace 则代表替换该项 tabItem。

当对象里的 pagePath 不存在初始的 tabList 时，则会新增该项 tabItem。

当对象里的 pagePath 存在初始的 tabList 时，则会修改该项 tabItem。